### PR TITLE
Add documentation and setup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+
+# Virtual environments
+.venv/
+ENV/
+venv/
+
+# PDF files
+*.pdf
+
+# Logs
+*.log
+
+# OS files
+.DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 PDF-ChineseText-Writer contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# PDF Chinese Text Writer
+
+This repository provides a simple example of using [PyMuPDF](https://pymupdf.readthedocs.io/) to insert Chinese text into an existing PDF file. The `AddTextToPDF.py` script opens a PDF, registers a CJK font and writes Chinese characters onto the first page.
+
+## Setup
+
+1. Install the dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Place the source PDF (e.g. `20250808_150601.pdf`) in the repository root.
+3. Run the script to generate a new PDF with the added text:
+
+```bash
+python AddTextToPDF.py
+```
+
+The output file will be saved with the `_AddText` suffix (e.g. `20250808_150601_AddText.pdf`).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+PyMuPDF


### PR DESCRIPTION
## Summary
- Add usage instructions and environment setup details in `README.md`.
- Introduce a Python-friendly `.gitignore` including PDF and environment artefacts.
- Declare project dependency `PyMuPDF` in `requirements.txt`.
- Include MIT license for reuse clarity.

## Testing
- `python -m py_compile AddTextToPDF.py`


------
https://chatgpt.com/codex/tasks/task_e_689c2eba4cd483229b952a4cd02e0dcb