### PR TITLE
Set license year to 2025

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 PDF-ChineseText-Writer contributors
+Copyright (c) 2025 PDF-ChineseText-Writer contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Use 2025 as the copyright year in LICENSE, reflecting the project's initial publication year

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c31af48a083229c0d2d8669857f3b